### PR TITLE
feat: inject avatars with dalle

### DIFF
--- a/supabase/functions/dalle-face-injection/index.ts
+++ b/supabase/functions/dalle-face-injection/index.ts
@@ -18,12 +18,13 @@ serve(async (req) => {
   }
 
   try {
-    const { 
-      illustrationUrl, 
-      avatarUrl, 
-      storyId, 
-      childId, 
+    const {
+      illustrationUrl,
+      avatarUrl,
+      storyId,
+      childId,
       pageIndex,
+      faceAnchor,
       emotion = 'happy',
       storyText = ''
     } = await req.json();
@@ -33,6 +34,23 @@ serve(async (req) => {
     const openAIKey = Deno.env.get('OPENAI_API_KEY');
     if (!openAIKey) {
       throw new Error('OpenAI API key not configured');
+    }
+
+    // Cache lookup
+    const cacheKey = `dalle_${storyId}_${childId}_${pageIndex}`;
+    const { data: cached } = await supabase
+      .from('personalized_images')
+      .select('image_url')
+      .eq('cache_key', cacheKey)
+      .single();
+    if (cached?.image_url) {
+      console.log('Returning cached personalized image');
+      return new Response(JSON.stringify({
+        success: true,
+        imageUrl: cached.image_url,
+        cacheKey,
+        cached: true
+      }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
     // Download the illustration image
@@ -49,27 +67,35 @@ serve(async (req) => {
     }
     const avatarBlob = await avatarResponse.blob();
 
-    // Load prebuilt mask from Supabase Storage (512x512)
-    let maskBlob: Blob;
-    try {
-      const { data: maskFile, error: maskErr } = await supabase.storage
-        .from('StoryVoyagers')
-        .download('masks/circle_512.png');
-      if (maskErr || !maskFile) {
-        throw maskErr || new Error('Mask file not found');
+    // Load mask from public storage URL
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const maskUrl = `${supabaseUrl}/storage/v1/object/public/StoryVoyagers/masks/circle_512.png`;
+    console.log('Downloading mask from', maskUrl);
+    const maskResp = await fetch(maskUrl);
+    if (!maskResp.ok) {
+      throw new Error('Failed to download mask image');
+    }
+    const rawMaskBlob = await maskResp.blob();
+
+    // Align mask with face anchor if provided
+    let maskBlob: Blob = rawMaskBlob;
+    if (faceAnchor) {
+      try {
+        const maskCanvas = new OffscreenCanvas(512, 512);
+        const mCtx = maskCanvas.getContext('2d')!;
+        mCtx.fillStyle = 'white';
+        mCtx.fillRect(0, 0, 512, 512);
+        const maskImg = await createImageBitmap(rawMaskBlob);
+        const r = faceAnchor.r || 256;
+        const x = faceAnchor.x || 256;
+        const y = faceAnchor.y || 256;
+        mCtx.globalCompositeOperation = 'destination-out';
+        mCtx.drawImage(maskImg, x - r, y - r, r * 2, r * 2);
+        maskBlob = await maskCanvas.convertToBlob();
+        console.log('Mask aligned using faceAnchor');
+      } catch (e) {
+        console.error('Failed to align mask with faceAnchor, using raw mask', e);
       }
-      maskBlob = maskFile as Blob;
-    } catch (e) {
-      console.error('Failed to download mask from storage:', e);
-      // Fallback: try public URL
-      const maskUrl = supabase.storage
-        .from('StoryVoyagers')
-        .getPublicUrl('masks/circle_512.png').data.publicUrl;
-      const maskResp = await fetch(maskUrl);
-      if (!maskResp.ok) {
-        throw new Error('Failed to fetch mask via public URL');
-      }
-      maskBlob = await maskResp.blob();
     }
     // Prepare the prompt based on emotion and story context
     const emotionPrompts = {
@@ -87,48 +113,50 @@ serve(async (req) => {
 
     console.log('Using prompt:', prompt);
 
-    // Create FormData for the DALL-E API request
-    const formData = new FormData();
-    formData.append('image', illustrationBlob, 'illustration.png');
-    formData.append('mask', maskBlob, 'mask.png');
-    formData.append('prompt', prompt);
-    formData.append('n', '1');
-    formData.append('size', '512x512');
+    let generatedBlob: Blob;
+    try {
+      console.log('Calling DALL-E inpainting API');
+      const formData = new FormData();
+      formData.append('image', illustrationBlob, 'illustration.png');
+      formData.append('image', avatarBlob, 'avatar.png');
+      formData.append('mask', maskBlob, 'mask.png');
+      formData.append('prompt', prompt);
+      formData.append('n', '1');
+      formData.append('size', '512x512');
 
-    // Call OpenAI DALL-E inpainting API
-    const dalleResponse = await fetch('https://api.openai.com/v1/images/edits', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${openAIKey}`,
-      },
-      body: formData,
-    });
+      const dalleResponse = await fetch('https://api.openai.com/v1/images/edits', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${openAIKey}`,
+        },
+        body: formData,
+      });
 
-    if (!dalleResponse.ok) {
-      const errorText = await dalleResponse.text();
-      console.error('DALL-E API error:', errorText);
-      throw new Error(`DALL-E API error: ${dalleResponse.status} ${errorText}`);
+      if (!dalleResponse.ok) {
+        const errorText = await dalleResponse.text();
+        throw new Error(`DALL-E API error: ${dalleResponse.status} ${errorText}`);
+      }
+
+      const dalleResult = await dalleResponse.json();
+      if (!dalleResult.data || dalleResult.data.length === 0) {
+        throw new Error('No images returned from DALL-E');
+      }
+      const generatedImageUrl = dalleResult.data[0].url;
+      const generatedResponse = await fetch(generatedImageUrl);
+      generatedBlob = await generatedResponse.blob();
+      console.log('DALL-E face injection succeeded');
+    } catch (dalleErr) {
+      console.error('DALL-E injection failed, falling back to canvas method:', dalleErr);
+      generatedBlob = await fallbackCanvas(illustrationBlob, avatarBlob, faceAnchor);
     }
-
-    const dalleResult = await dalleResponse.json();
-    console.log('DALL-E result:', dalleResult);
-
-    if (!dalleResult.data || dalleResult.data.length === 0) {
-      throw new Error('No images returned from DALL-E');
-    }
-
-    // Download the generated image
-    const generatedImageUrl = dalleResult.data[0].url;
-    const generatedResponse = await fetch(generatedImageUrl);
-    const generatedBlob = await generatedResponse.blob();
 
     // Upload to Supabase storage
-    const fileName = `personalized/${storyId}/${childId}/page-${pageIndex}-dalle.png`;
+    const fileName = `rendered/${storyId}/${childId}/page-${pageIndex}.png`;
     const { error: uploadError } = await supabase.storage
       .from('StoryVoyagers')
-      .upload(fileName, generatedBlob, { 
-        contentType: 'image/png', 
-        upsert: true 
+      .upload(fileName, generatedBlob, {
+        contentType: 'image/png',
+        upsert: true
       });
 
     if (uploadError) {
@@ -141,7 +169,6 @@ serve(async (req) => {
       .getPublicUrl(fileName).data.publicUrl;
 
     // Cache the result in the database
-    const cacheKey = `dalle_${storyId}_${childId}_${pageIndex}`;
     await supabase
       .from('personalized_images')
       .upsert({
@@ -153,7 +180,7 @@ serve(async (req) => {
         emotion: emotion,
       }, { onConflict: 'cache_key' });
 
-    console.log('Successfully generated and saved DALL-E personalized image:', publicUrl);
+    console.log('Successfully generated and saved personalized image:', publicUrl);
 
     return new Response(JSON.stringify({ 
       success: true, 
@@ -165,8 +192,8 @@ serve(async (req) => {
 
   } catch (error) {
     console.error('Error in DALL-E face injection:', error);
-    return new Response(JSON.stringify({ 
-      error: error.message 
+    return new Response(JSON.stringify({
+      error: error.message
     }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -174,4 +201,44 @@ serve(async (req) => {
   }
 });
 
-// Mask is loaded from Supabase Storage at StoryVoyagers/masks/circle_512.png
+async function fallbackCanvas(
+  illustrationBlob: Blob,
+  avatarBlob: Blob,
+  faceAnchor: { x: number; y: number; r: number } | undefined
+): Promise<Blob> {
+  console.log('Running canvas fallback method');
+
+  const [illustrationArray, avatarArray] = await Promise.all([
+    illustrationBlob.arrayBuffer(),
+    avatarBlob.arrayBuffer(),
+  ]);
+
+  const illustrationBase64 = btoa(String.fromCharCode(...new Uint8Array(illustrationArray)));
+  const avatarBase64 = btoa(String.fromCharCode(...new Uint8Array(avatarArray)));
+
+  const baseImg = new Image();
+  baseImg.src = `data:image/png;base64,${illustrationBase64}`;
+  await new Promise((res) => (baseImg.onload = res));
+
+  const avatarImg = new Image();
+  avatarImg.src = `data:image/png;base64,${avatarBase64}`;
+  await new Promise((res) => (avatarImg.onload = res));
+
+  const canvas = new OffscreenCanvas(baseImg.width, baseImg.height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(baseImg, 0, 0);
+
+  const anchor = faceAnchor || { x: baseImg.width / 2, y: baseImg.height / 2, r: 128 };
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(anchor.x, anchor.y, anchor.r, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.clip();
+  ctx.drawImage(avatarImg, anchor.x - anchor.r, anchor.y - anchor.r, anchor.r * 2, anchor.r * 2);
+  ctx.restore();
+
+  const blob = await canvas.convertToBlob({ type: 'image/png' });
+  console.log('Canvas fallback complete');
+  return blob;
+}
+


### PR DESCRIPTION
## Summary
- fetch mask via public storage URL and align using face anchor
- blend child avatars into illustrations with DALL·E inpainting and fallback canvas method
- cache and store rendered images per story/child/page

## Testing
- `npm run lint` *(fails: Unexpected any; Unexpected lexical declaration; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0965f599c832cae2de09464978984