### PR TITLE
feat: inject avatars with dalle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,11 +47,11 @@ const Header = () => {
           <Link to={user ? "/" : "/about"} className="flex items-center space-x-3">
             <img 
               src="/lovable-uploads/3bf06096-e00d-42ad-b576-8d028ecb75d9.png" 
-              alt="StoryVoyagers Logo" 
+              alt="Meroe Logo"
               className="h-10 w-10 rounded-xl"
             />
             <div>
-              <h1 className="font-fredoka font-bold text-xl">StoryVoyagers</h1>
+              <h1 className="font-fredoka font-bold text-xl">Meroe</h1>
               <p className="text-xs text-muted-foreground">Educational Adventures</p>
             </div>
           </Link>

--- a/src/components/SupabaseConnectionPrompt.tsx
+++ b/src/components/SupabaseConnectionPrompt.tsx
@@ -23,7 +23,7 @@ const SupabaseConnectionPrompt = () => {
         <CardContent className="space-y-6">
           <div className="text-center space-y-3">
             <p className="text-muted-foreground">
-              To enable authentication, data storage, and all the amazing features of StoryVoyagers, 
+              To enable authentication, data storage, and all the amazing features of Meroe,
               you need to connect your Supabase project.
             </p>
           </div>

--- a/src/hooks/useAvatarInjection.ts
+++ b/src/hooks/useAvatarInjection.ts
@@ -55,7 +55,7 @@ export const useAvatarInjection = () => {
 
   const getInjectedImageUrl = (storyId: string, pageIndex: number): string => {
     return supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .getPublicUrl(`story_injected/${storyId}/page_${pageIndex}.png`).data.publicUrl;
   };
 

--- a/src/hooks/useFaceInjection.ts
+++ b/src/hooks/useFaceInjection.ts
@@ -37,11 +37,11 @@ export const useFaceInjection = () => {
   const uploadAndRecord = async (cacheKey: string, storyId: string, childId: string, pageIndex: number, blob: Blob) => {
     const path = `personalized/${storyId}/${childId}/page-${pageIndex}.png`;
     const { error: uploadErr } = await supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .upload(path, blob, { contentType: 'image/png', upsert: true });
     if (uploadErr) throw uploadErr;
 
-    const publicUrl = `${supabase.storage.from('StoryVoyagers').getPublicUrl(path).data.publicUrl}`;
+    const publicUrl = `${supabase.storage.from('Meroe').getPublicUrl(path).data.publicUrl}`;
 
     await supabase
       .from('personalized_images')

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -33,7 +33,7 @@ const About = () => {
                 <Sparkles className="h-6 w-6 text-white" />
               </div>
               <div>
-                <h1 className="font-fredoka font-bold text-xl">StoryVoyagers</h1>
+                <h1 className="font-fredoka font-bold text-xl">Meroe</h1>
                 <p className="text-xs text-muted-foreground">Educational Adventures</p>
               </div>
             </div>

--- a/supabase/functions/dalle-face-injection/index.ts
+++ b/supabase/functions/dalle-face-injection/index.ts
@@ -18,12 +18,13 @@ serve(async (req) => {
   }
 
   try {
-    const { 
-      illustrationUrl, 
-      avatarUrl, 
-      storyId, 
-      childId, 
+    const {
+      illustrationUrl,
+      avatarUrl,
+      storyId,
+      childId,
       pageIndex,
+      faceAnchor,
       emotion = 'happy',
       storyText = ''
     } = await req.json();
@@ -33,6 +34,23 @@ serve(async (req) => {
     const openAIKey = Deno.env.get('OPENAI_API_KEY');
     if (!openAIKey) {
       throw new Error('OpenAI API key not configured');
+    }
+
+    // Cache lookup
+    const cacheKey = `dalle_${storyId}_${childId}_${pageIndex}`;
+    const { data: cached } = await supabase
+      .from('personalized_images')
+      .select('image_url')
+      .eq('cache_key', cacheKey)
+      .single();
+    if (cached?.image_url) {
+      console.log('Returning cached personalized image');
+      return new Response(JSON.stringify({
+        success: true,
+        imageUrl: cached.image_url,
+        cacheKey,
+        cached: true
+      }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
     // Download the illustration image
@@ -49,27 +67,35 @@ serve(async (req) => {
     }
     const avatarBlob = await avatarResponse.blob();
 
-    // Load prebuilt mask from Supabase Storage (512x512)
-    let maskBlob: Blob;
-    try {
-      const { data: maskFile, error: maskErr } = await supabase.storage
-        .from('StoryVoyagers')
-        .download('masks/circle_512.png');
-      if (maskErr || !maskFile) {
-        throw maskErr || new Error('Mask file not found');
+    // Load mask from public storage URL
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const maskUrl = `${supabaseUrl}/storage/v1/object/public/Meroe/masks/circle_512.png`;
+    console.log('Downloading mask from', maskUrl);
+    const maskResp = await fetch(maskUrl);
+    if (!maskResp.ok) {
+      throw new Error('Failed to download mask image');
+    }
+    const rawMaskBlob = await maskResp.blob();
+
+    // Align mask with face anchor if provided
+    let maskBlob: Blob = rawMaskBlob;
+    if (faceAnchor) {
+      try {
+        const maskCanvas = new OffscreenCanvas(512, 512);
+        const mCtx = maskCanvas.getContext('2d')!;
+        mCtx.fillStyle = 'white';
+        mCtx.fillRect(0, 0, 512, 512);
+        const maskImg = await createImageBitmap(rawMaskBlob);
+        const r = faceAnchor.r || 256;
+        const x = faceAnchor.x || 256;
+        const y = faceAnchor.y || 256;
+        mCtx.globalCompositeOperation = 'destination-out';
+        mCtx.drawImage(maskImg, x - r, y - r, r * 2, r * 2);
+        maskBlob = await maskCanvas.convertToBlob();
+        console.log('Mask aligned using faceAnchor');
+      } catch (e) {
+        console.error('Failed to align mask with faceAnchor, using raw mask', e);
       }
-      maskBlob = maskFile as Blob;
-    } catch (e) {
-      console.error('Failed to download mask from storage:', e);
-      // Fallback: try public URL
-      const maskUrl = supabase.storage
-        .from('StoryVoyagers')
-        .getPublicUrl('masks/circle_512.png').data.publicUrl;
-      const maskResp = await fetch(maskUrl);
-      if (!maskResp.ok) {
-        throw new Error('Failed to fetch mask via public URL');
-      }
-      maskBlob = await maskResp.blob();
     }
     // Prepare the prompt based on emotion and story context
     const emotionPrompts = {
@@ -87,48 +113,50 @@ serve(async (req) => {
 
     console.log('Using prompt:', prompt);
 
-    // Create FormData for the DALL-E API request
-    const formData = new FormData();
-    formData.append('image', illustrationBlob, 'illustration.png');
-    formData.append('mask', maskBlob, 'mask.png');
-    formData.append('prompt', prompt);
-    formData.append('n', '1');
-    formData.append('size', '512x512');
+    let generatedBlob: Blob;
+    try {
+      console.log('Calling DALL-E inpainting API');
+      const formData = new FormData();
+      formData.append('image', illustrationBlob, 'illustration.png');
+      formData.append('image', avatarBlob, 'avatar.png');
+      formData.append('mask', maskBlob, 'mask.png');
+      formData.append('prompt', prompt);
+      formData.append('n', '1');
+      formData.append('size', '512x512');
 
-    // Call OpenAI DALL-E inpainting API
-    const dalleResponse = await fetch('https://api.openai.com/v1/images/edits', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${openAIKey}`,
-      },
-      body: formData,
-    });
+      const dalleResponse = await fetch('https://api.openai.com/v1/images/edits', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${openAIKey}`,
+        },
+        body: formData,
+      });
 
-    if (!dalleResponse.ok) {
-      const errorText = await dalleResponse.text();
-      console.error('DALL-E API error:', errorText);
-      throw new Error(`DALL-E API error: ${dalleResponse.status} ${errorText}`);
+      if (!dalleResponse.ok) {
+        const errorText = await dalleResponse.text();
+        throw new Error(`DALL-E API error: ${dalleResponse.status} ${errorText}`);
+      }
+
+      const dalleResult = await dalleResponse.json();
+      if (!dalleResult.data || dalleResult.data.length === 0) {
+        throw new Error('No images returned from DALL-E');
+      }
+      const generatedImageUrl = dalleResult.data[0].url;
+      const generatedResponse = await fetch(generatedImageUrl);
+      generatedBlob = await generatedResponse.blob();
+      console.log('DALL-E face injection succeeded');
+    } catch (dalleErr) {
+      console.error('DALL-E injection failed, falling back to canvas method:', dalleErr);
+      generatedBlob = await fallbackCanvas(illustrationBlob, avatarBlob, faceAnchor);
     }
-
-    const dalleResult = await dalleResponse.json();
-    console.log('DALL-E result:', dalleResult);
-
-    if (!dalleResult.data || dalleResult.data.length === 0) {
-      throw new Error('No images returned from DALL-E');
-    }
-
-    // Download the generated image
-    const generatedImageUrl = dalleResult.data[0].url;
-    const generatedResponse = await fetch(generatedImageUrl);
-    const generatedBlob = await generatedResponse.blob();
 
     // Upload to Supabase storage
-    const fileName = `personalized/${storyId}/${childId}/page-${pageIndex}-dalle.png`;
+    const fileName = `rendered/${storyId}/${childId}/page-${pageIndex}.png`;
     const { error: uploadError } = await supabase.storage
-      .from('StoryVoyagers')
-      .upload(fileName, generatedBlob, { 
-        contentType: 'image/png', 
-        upsert: true 
+      .from('Meroe')
+      .upload(fileName, generatedBlob, {
+        contentType: 'image/png',
+        upsert: true
       });
 
     if (uploadError) {
@@ -137,11 +165,10 @@ serve(async (req) => {
 
     // Get the public URL
     const publicUrl = supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .getPublicUrl(fileName).data.publicUrl;
 
     // Cache the result in the database
-    const cacheKey = `dalle_${storyId}_${childId}_${pageIndex}`;
     await supabase
       .from('personalized_images')
       .upsert({
@@ -153,7 +180,7 @@ serve(async (req) => {
         emotion: emotion,
       }, { onConflict: 'cache_key' });
 
-    console.log('Successfully generated and saved DALL-E personalized image:', publicUrl);
+    console.log('Successfully generated and saved personalized image:', publicUrl);
 
     return new Response(JSON.stringify({ 
       success: true, 
@@ -165,8 +192,8 @@ serve(async (req) => {
 
   } catch (error) {
     console.error('Error in DALL-E face injection:', error);
-    return new Response(JSON.stringify({ 
-      error: error.message 
+    return new Response(JSON.stringify({
+      error: error.message
     }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -174,4 +201,44 @@ serve(async (req) => {
   }
 });
 
-// Mask is loaded from Supabase Storage at StoryVoyagers/masks/circle_512.png
+async function fallbackCanvas(
+  illustrationBlob: Blob,
+  avatarBlob: Blob,
+  faceAnchor: { x: number; y: number; r: number } | undefined
+): Promise<Blob> {
+  console.log('Running canvas fallback method');
+
+  const [illustrationArray, avatarArray] = await Promise.all([
+    illustrationBlob.arrayBuffer(),
+    avatarBlob.arrayBuffer(),
+  ]);
+
+  const illustrationBase64 = btoa(String.fromCharCode(...new Uint8Array(illustrationArray)));
+  const avatarBase64 = btoa(String.fromCharCode(...new Uint8Array(avatarArray)));
+
+  const baseImg = new Image();
+  baseImg.src = `data:image/png;base64,${illustrationBase64}`;
+  await new Promise((res) => (baseImg.onload = res));
+
+  const avatarImg = new Image();
+  avatarImg.src = `data:image/png;base64,${avatarBase64}`;
+  await new Promise((res) => (avatarImg.onload = res));
+
+  const canvas = new OffscreenCanvas(baseImg.width, baseImg.height);
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(baseImg, 0, 0);
+
+  const anchor = faceAnchor || { x: baseImg.width / 2, y: baseImg.height / 2, r: 128 };
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(anchor.x, anchor.y, anchor.r, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.clip();
+  ctx.drawImage(avatarImg, anchor.x - anchor.r, anchor.y - anchor.r, anchor.r * 2, anchor.r * 2);
+  ctx.restore();
+
+  const blob = await canvas.convertToBlob({ type: 'image/png' });
+  console.log('Canvas fallback complete');
+  return blob;
+}
+

--- a/supabase/functions/inject-avatar/index.ts
+++ b/supabase/functions/inject-avatar/index.ts
@@ -39,13 +39,13 @@ serve(async (req) => {
     // Check if injected image already exists
     const injectedPath = `story_injected/${story_id}/page_${page_index}.png`;
     const { data: existingFile } = await supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .list(`story_injected/${story_id}/`, { search: `page_${page_index}.png` });
 
     if (existingFile && existingFile.length > 0) {
       console.log('Using existing injected image');
       const publicUrl = supabase.storage
-        .from('StoryVoyagers')
+        .from('Meroe')
         .getPublicUrl(injectedPath).data.publicUrl;
       
       return new Response(JSON.stringify({ 
@@ -68,7 +68,7 @@ serve(async (req) => {
     let maskBlob: Blob;
     try {
       const { data: maskFile, error: maskErr } = await supabase.storage
-        .from('StoryVoyagers')
+        .from('Meroe')
         .download('masks/circle_512.png');
       if (maskErr || !maskFile) {
         throw maskErr || new Error('Mask file not found');
@@ -78,7 +78,7 @@ serve(async (req) => {
       console.error('Failed to download mask from storage:', e);
       // Fallback: try public URL
       const maskUrl = supabase.storage
-        .from('StoryVoyagers')
+        .from('Meroe')
         .getPublicUrl('masks/circle_512.png').data.publicUrl;
       const maskResp = await fetch(maskUrl);
       if (!maskResp.ok) {
@@ -150,7 +150,7 @@ serve(async (req) => {
 
     // Upload to Supabase storage
     const { error: uploadError } = await supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .upload(injectedPath, generatedBlob, { 
         contentType: 'image/png', 
         upsert: true 
@@ -162,7 +162,7 @@ serve(async (req) => {
 
     // Get the public URL
     const publicUrl = supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .getPublicUrl(injectedPath).data.publicUrl;
 
     console.log('Successfully generated and saved injected image:', publicUrl);

--- a/supabase/functions/personalize-story-image/index.ts
+++ b/supabase/functions/personalize-story-image/index.ts
@@ -81,7 +81,7 @@ serve(async (req) => {
     // Upload the personalized image to Supabase Storage
     const fileName = `personalized/${cacheKey}_${Date.now()}.png`;
     const { data: uploadData, error: uploadError } = await supabase.storage
-      .from('StoryVoyagers')
+      .from('Meroe')
       .upload(fileName, personalizedImage, {
         contentType: 'image/png',
         cacheControl: '3600'
@@ -91,7 +91,7 @@ serve(async (req) => {
       throw new Error(`Failed to upload personalized image: ${uploadError.message}`);
     }
 
-    const personalizedImageUrl = `${supabaseUrl}/storage/v1/object/public/StoryVoyagers/${fileName}`;
+    const personalizedImageUrl = `${supabaseUrl}/storage/v1/object/public/Meroe/${fileName}`;
 
     // Cache the result
     await supabase

--- a/supabase/migrations/20250909034757_931bbccc-ddae-48d9-bc6d-e2f5f3bc699d.sql
+++ b/supabase/migrations/20250909034757_931bbccc-ddae-48d9-bc6d-e2f5f3bc699d.sql
@@ -1,12 +1,12 @@
 -- Fix storage policies for face injection
--- Create storage policies for the StoryVoyagers bucket to allow personalized image uploads
+-- Create storage policies for the Meroe bucket to allow personalized image uploads
 
 -- Allow authenticated users to upload personalized images to their own folders
 CREATE POLICY "Users can upload personalized images" 
 ON storage.objects 
 FOR INSERT 
 WITH CHECK (
-  bucket_id = 'StoryVoyagers' 
+  bucket_id = 'Meroe' 
   AND auth.uid() IS NOT NULL
   AND (storage.foldername(name))[1] = 'personalized'
 );
@@ -16,7 +16,7 @@ CREATE POLICY "Users can view personalized images"
 ON storage.objects 
 FOR SELECT 
 USING (
-  bucket_id = 'StoryVoyagers'
+  bucket_id = 'Meroe'
   AND (
     -- Allow public access to public story images
     (storage.foldername(name))[1] != 'personalized'
@@ -31,7 +31,7 @@ CREATE POLICY "Users can update personalized images"
 ON storage.objects 
 FOR UPDATE 
 USING (
-  bucket_id = 'StoryVoyagers' 
+  bucket_id = 'Meroe' 
   AND auth.uid() IS NOT NULL
   AND (storage.foldername(name))[1] = 'personalized'
 );

--- a/supabase/migrations/20250909034818_388cc43d-eb8d-4fff-b7a0-d5cc570a13e2.sql
+++ b/supabase/migrations/20250909034818_388cc43d-eb8d-4fff-b7a0-d5cc570a13e2.sql
@@ -1,12 +1,12 @@
 -- Fix storage policies for face injection
--- Create storage policies for the StoryVoyagers bucket to allow personalized image uploads
+-- Create storage policies for the Meroe bucket to allow personalized image uploads
 
 -- Allow authenticated users to upload personalized images to their own folders
 CREATE POLICY "Users can upload personalized images" 
 ON storage.objects 
 FOR INSERT 
 WITH CHECK (
-  bucket_id = 'StoryVoyagers' 
+  bucket_id = 'Meroe' 
   AND auth.uid() IS NOT NULL
   AND (storage.foldername(name))[1] = 'personalized'
 );
@@ -16,7 +16,7 @@ CREATE POLICY "Users can view personalized images"
 ON storage.objects 
 FOR SELECT 
 USING (
-  bucket_id = 'StoryVoyagers'
+  bucket_id = 'Meroe'
   AND (
     -- Allow public access to public story images
     (storage.foldername(name))[1] != 'personalized'
@@ -31,7 +31,7 @@ CREATE POLICY "Users can update personalized images"
 ON storage.objects 
 FOR UPDATE 
 USING (
-  bucket_id = 'StoryVoyagers' 
+  bucket_id = 'Meroe' 
   AND auth.uid() IS NOT NULL
   AND (storage.foldername(name))[1] = 'personalized'
 );

--- a/supabase/migrations/20250909204356_df85550a-03a6-44a9-8b93-f29d1242943d.sql
+++ b/supabase/migrations/20250909204356_df85550a-03a6-44a9-8b93-f29d1242943d.sql
@@ -1,13 +1,13 @@
 -- Upload circular mask to Supabase Storage
 -- This will be used by the inject-avatar edge function for DALL-E inpainting
 
--- First ensure the masks directory exists in StoryVoyagers bucket
--- The mask image will be uploaded manually to: StoryVoyagers/masks/circle_512.png
+-- First ensure the masks directory exists in Meroe bucket
+-- The mask image will be uploaded manually to: Meroe/masks/circle_512.png
 
 -- Create a simple function to help with mask creation if needed in the future
 CREATE OR REPLACE FUNCTION public.get_mask_url(mask_name TEXT DEFAULT 'circle_512.png')
 RETURNS TEXT AS $$
 BEGIN
-  RETURN 'https://bsjjxgpaxfawoyjgufgo.supabase.co/storage/v1/object/public/StoryVoyagers/masks/' || mask_name;
+  RETURN 'https://bsjjxgpaxfawoyjgufgo.supabase.co/storage/v1/object/public/Meroe/masks/' || mask_name;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- fetch mask via public storage URL and align using face anchor
- blend child avatars into illustrations with DALL·E inpainting and fallback canvas method
- cache and store rendered images per story/child/page
- rename app from StoryVoyagers to Meroe across code and migrations

## Testing
- `npm run lint` *(fails: Unexpected any, Unexpected lexical declaration, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0965f599c832cae2de09464978984